### PR TITLE
Change dict/seq checks to use collections ABCs (for duck-typed params)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# PyCharm/IDEA
+.idea/*

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Abstract base classes defined in the *collections* module are supported for duck
    ```Python
    import collections
    
-   def DuckTypedList(collections.Mapping):
+   def DuckTypedList(collections.MutableSequence):
       def __getitem__(self, item):
           pass
       def __iter__(self):
@@ -146,7 +146,7 @@ Abstract base classes defined in the *collections* module are supported for duck
           pass
           
    @typecheck
-   def foo(m: collections.Mapping):
+   def foo(m: collections.MutableSequence):
        pass
    ```
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,33 @@ each value is allowed by values_annot.
    foo({"1": "2"})     # Wrong: violates values_annot of argument
                          (also violates keys_annot of result)
    ```
+   
+**tc.mapping_of(keys_annot, values_annot)**:
+
+Takes two annotations ``keys_annot`` and ``values_annot``.
+Exactly like dict_of except allows arguments that satisfy the *abstract base class* Mapping (defined in collections).
+This allows duck-typed dict-like classes.
+
+   ```Python
+   class DuckTypedDict(collections.Mapping):
+      def __getitem__(self, item):
+         pass
+      def __iter__(self):
+         pass
+      def __len__(self):
+         pass
+   
+   @typecheck
+   def foo_do(map: tc.mapping_of(int, str)) -> tc.mapping_of(str, int):
+       return { v: k  for k,v in x.items() }
+
+   foo(DuckTypedDict())  # OK
+   assert foo({1: "one", 2: "two"}) == {"one": 1, "two": 2}  # OK
+   foo({})             # OK: an empty dict is still a dict
+   foo(None)           # Wrong: None is not a dict
+   foo({"1": "2"})     # Wrong: violates values_annot of argument
+                         (also violates keys_annot of result)
+   ```
 
 **tc.enum(*values)**:
 
@@ -366,6 +393,56 @@ Effectively defines an arbitrary, ad-hoc enumeration type.
    foo_ev(1)     # OK
    foo_ev(1.0)   # Wrong: not in values list
    foo_ev([1,1,1,1])  # OK
+   ```
+
+**tc.issequence**:
+
+Takes no arguments.
+Allows any argument that satisfies the *abstract base class* Sequence (defined in collections) except string. This allows
+duck-typed list-like classes.
+
+   ```Python
+   import collections
+   
+   class DuckTypedList(collections.Sequence):
+      def __getitem__(self, item):
+         pass
+      def __len__(self):
+         pass
+   
+   @typecheck
+   def foo(arg: tc.issequence): pass
+
+   foo(DuckTypedList())  # OK
+   foo([1, 2, 3])        # OK
+   foo((1, 2, 3))        # OK
+   foo(123)              # Wrong: not a sequence
+   foo("hi")             # Wrong: string
+   ```
+
+**tc.ismapping**:
+
+Takes no arguments.
+Allows any argument that satisfies the *abstract base class* Mapping (defined in collections) except string. This allows
+duck-typed dict-like classes.
+
+   ```Python
+   import collections
+   
+   class DuckTypedDict(collections.Mapping):
+      def __getitem__(self, item):
+         pass
+      def __iter__(self):
+         pass
+      def __len__(self):
+         pass
+   
+   @typecheck
+   def foo(arg: tc.ismapping): pass
+
+   foo(DuckTypedDict())  # OK
+   foo({"a": 1})         # OK
+   foo([1, 2, 3])        # Wrong: not a mapping
    ```
 
 **tc.any(*annots)**:

--- a/typecheck/test_typecheck_decorator.py
+++ b/typecheck/test_typecheck_decorator.py
@@ -6,6 +6,7 @@
 import functools
 import platform
 import re
+import collections
 from random import randint, shuffle
 from time import time
 from traceback import extract_stack
@@ -1354,6 +1355,56 @@ print("ok")
 
 ############################################################################
 
+print("mapping_of: ", end="")
+
+@typecheck
+def foo(x: tc.mapping_of(int, str)) -> tc.mapping_of(str, int):
+    return { v: k for k, v in x.items() }
+
+assert foo({}) == {}
+assert foo({1: "1", 2: "2"}) == {"1": 1, "2": 2}
+
+with expected(InputParameterError("foo() has got an incompatible value for x: []")):
+    foo([])
+
+with expected(InputParameterError("foo() has got an incompatible value for x: {'1': '2'}")):
+    foo({"1": "2"})
+
+with expected(InputParameterError("foo() has got an incompatible value for x: {1: 2}")):
+    foo({1: 2})
+
+###################
+
+@typecheck
+def foo(*, k: tc.mapping_of((int, int), [tc.has("^[0-9]+$"), tc.has("^[0-9]+$")])):
+    return functools.reduce(lambda r, t: r and str(t[0][0]) == t[1][0] and str(t[0][1]) == t[1][1],
+                            k.items(), True)
+
+assert foo(k = { (1, 2): ["1", "2"], (3, 4): ["3", "4"]})
+assert not foo(k = { (1, 3): ["1", "2"], (3, 4): ["3", "4"]})
+assert not foo(k = { (1, 2): ["1", "2"], (3, 4): ["3", "5"]})
+
+with expected(InputParameterError("foo() has got an incompatible value for k: {(1, 2): ['1', '2'], (3, 4): ['3', 'x']}")):
+    foo(k = { (1, 2): ["1", "2"], (3, 4): ["3", "x"]})
+
+with expected(InputParameterError("foo() has got an incompatible value for k: {(1, 2): ['1', '2'], (3,): ['3', '4']}")):
+    foo(k = { (1, 2): ["1", "2"], (3, ): ["3", "4"]})
+
+with expected(InputParameterError("foo() has got an incompatible value for k: {(1, 2): ['1', '2'], (3, 4.0): ['3', '4']}")):
+    foo(k = { (1, 2): ["1", "2"], (3, 4.0): ["3", "4"]})
+
+###################
+
+assert tc.mapping_of(int, tc.optional(str))({ 1: "foo", 2: None }) and \
+       tc.mapping_of(int, tc.optional(str)).check({ 1: "foo", 2: None })
+
+assert not tc.mapping_of(int, tc.optional(str))({ None: "foo", 2: None }) and \
+       not tc.mapping_of(int, tc.optional(str)).check({ None: "foo", 2: None })
+
+print("ok")
+
+############################################################################
+
 print("enum: ", end="")
 
 @typecheck
@@ -1383,6 +1434,59 @@ def foo(x: tc.optional(tc.enum(1, 2)) = 2):
     return x
 
 assert foo() == 2
+
+print("ok")
+
+############################################################################
+
+print("issequence: ", end="")
+
+@typecheck
+def foo(x: tc.issequence):
+    pass
+
+class FooSequence(collections.Sequence):
+    def __getitem__(self, item):
+        pass
+    def __len__(self):
+        pass
+
+foo(FooSequence())
+foo((1, 2, 3))
+foo([1, 2, 3])
+
+with expected(InputParameterError("foo() has got an incompatible value for x: 123")):
+    foo(123)
+
+with expected(InputParameterError("foo() has got an incompatible value for x: X")):
+    foo("X")
+
+print("ok")
+
+############################################################################
+
+print("ismapping: ", end="")
+
+@typecheck
+def foo(x: tc.ismapping):
+    pass
+
+class FooMapping(collections.Mapping):
+    def __getitem__(self, item):
+        pass
+    def __iter__(self):
+        pass
+    def __len__(self):
+        pass
+
+foo(FooMapping())
+foo({"a": 1})
+
+with expected(InputParameterError("foo() has got an incompatible value for x: [1, 2, 3]")):
+    foo([1, 2, 3])
+
+with expected(InputParameterError("foo() has got an incompatible value for x: X")):
+    foo("X")
 
 print("ok")
 

--- a/typecheck/typecheck_decorator.py
+++ b/typecheck/typecheck_decorator.py
@@ -32,6 +32,7 @@ import builtins
 import inspect
 import functools
 import re
+import collections
 
 callable = lambda x: hasattr(x, "__call__")
 anything = lambda x: True
@@ -179,10 +180,9 @@ class SequenceOfChecker(Checker):
 
     def __init__(self, check):
         self._check = Checker.create(check)
-        self._allowable_types = (list, tuple)
 
     def check(self, value):
-        return builtins.any([isinstance(value, t) for t in self._allowable_types]) and \
+        return isinstance(value, collections.Sequence) and \
                functools.reduce(lambda r, v: r and self._check.check(v), value, True)
 
 sequence_of = SequenceOfChecker
@@ -216,7 +216,7 @@ class DictOfChecker(Checker):
         self._value_check = Checker.create(value_check)
 
     def check(self, value):
-        return isinstance(value, dict) and \
+        return isinstance(value, collections.Mapping) and \
                functools.reduce(lambda r, t: r and self._key_check.check(t[0]) and \
                                              self._value_check.check(t[1]),
                                 value.items(), True)

--- a/typecheck/typecheck_decorator.py
+++ b/typecheck/typecheck_decorator.py
@@ -189,21 +189,27 @@ sequence_of = SequenceOfChecker
 
 ################################################################################
 
-class TupleOfChecker(SequenceOfChecker):
+class TupleOfChecker(Checker):
 
     def __init__(self, check):
         self._check = Checker.create(check)
-        self._allowable_types = (tuple,)
+
+    def check(self, value):
+        return isinstance(value, tuple) and \
+            functools.reduce(lambda r, v: r and self._check.check(v), value, True)
 
 tuple_of = TupleOfChecker
 
 ################################################################################
 
-class ListOfChecker(SequenceOfChecker):
+class ListOfChecker(Checker):
 
     def __init__(self, check):
         self._check = Checker.create(check)
-        self._allowable_types = (list,)
+
+    def check(self, value):
+        return isinstance(value, list) and \
+            functools.reduce(lambda r, v: r and self._check.check(v), value, True)
 
 list_of = ListOfChecker
 

--- a/typecheck/typecheck_decorator.py
+++ b/typecheck/typecheck_decorator.py
@@ -32,7 +32,6 @@ import inspect
 import functools
 import re
 import collections
-import sys
 
 callable = lambda x: hasattr(x, "__call__")
 anything = lambda x: True

--- a/typecheck/typecheck_decorator.py
+++ b/typecheck/typecheck_decorator.py
@@ -150,10 +150,7 @@ has = RegexChecker
 
 ################################################################################
 
-def isstring(x):
-    tc = TypeChecker(basestring if sys.version_info[0] == 2 else str)
-    return tc.check(x)
-
+isstring = lambda x: isinstance(x, str)
 issequence = lambda x: isinstance(x, collections.Sequence) and not isstring(x)
 
 class FixedSequenceChecker(Checker):


### PR DESCRIPTION
This allows parameters that provide sufficient interface to be used as dictionaries or sequence types (list/tuple) to pass the respective checks.