### PR TITLE
fix None check, grammar

### DIFF
--- a/typecheck/typecheck_decorator.py
+++ b/typecheck/typecheck_decorator.py
@@ -77,6 +77,20 @@ class Checker:
 
 ################################################################################
 
+isnone = lambda x: x is None
+
+class NoneChecker(Checker):
+
+    def __init__(self, cls):
+        self._cls = cls
+
+    def check(self, value):
+        return value is None
+
+Checker.register(isnone, NoneChecker)
+
+################################################################################
+
 class TypeChecker(Checker):
 
     def __init__(self, cls):
@@ -356,14 +370,14 @@ def typecheck(method, *, input_parameter_error = InputParameterError,
             if check is not None:
                 arg_name, checker = check
                 if not checker.check(arg):
-                    raise input_parameter_error("{0}() has got an incompatible value "
+                    raise input_parameter_error("{0}() has an incompatible value "
                                                 "for {1}: {2}".format(method_name, arg_name,
                                                                       str(arg) == "" and "''" or arg))
 
         for arg_name, checker in kwarg_checkers.items():
             kwarg = kwargs.get(arg_name, Checker.no_value)
             if not checker.check(kwarg):
-                raise input_parameter_error("{0}() has got an incompatible value "
+                raise input_parameter_error("{0}() has an incompatible value "
                                             "for {1}: {2}".format(method_name, arg_name,
                                                                   str(kwarg) == "" and "''" or kwarg))
 


### PR DESCRIPTION
Hi Lutz,

All the changes you made look great to me. I have two small additions: first is just a simple grammar correction, the second adds the ability to use a bare None as a typecheck value, for example enabling this usage:

```python
# enforces function does not return anything
@typecheck
def foo(x: int) -> None: pass

#enforces dict values of integers or None
@typecheck
def foo(x: tc.dict_of(int, tc.any(None, int))): pass
```

Although it works I'm not sure I implemented it 100% correctly. I don't know why it needs the None check both in the predicate and in the Checker.check() method. Perhaps you could clean it up a bit.

Regardless of whether you think it's a good addition (I won't be offended if you do not merge it), I think typecheck-decorator is ready for 1.0. I'm already using it extensively in a bunch of production code.

Cheers,
Ben