### PR TITLE
Disable typechecking by default in optimized mode: python -O

### DIFF
--- a/typecheck/framework.py
+++ b/typecheck/framework.py
@@ -4,7 +4,7 @@ import typing as tg
 
 ################################################################################
 
-_enabled = True
+_enabled = __debug__  # disable typchecking in optimized mode: python -O
 
 
 def disable():
@@ -103,7 +103,6 @@ class TypeVarNamespace:
         rebind the type variable to supertypes of the current binding several
         times until the required most general binding is found.
         """
-        result = True
         binding = self.binding_of(typevar)  # may or may not exist
         if binding is None:
             self.bind(typevar, its_type)  # initial binding, OK


### PR DESCRIPTION
Also, removed an unused variable `result` from is_compatible()

By the way, if you're taking pull requests, I implemented a decorator that makes all methods of a class type checked. Simple, but effort saving. If you're interested, I'll write test cases and documentation, and submit a request.

Really neat project by the way. Very nice organization and style as well.
