### PR TITLE
Missing return in is_even function in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ as its only argument and must return a value that evaluates to
 Example:
 
    ```Python
-   def is_even(n): type(n) is int and n%2 == 0
+   def is_even(n): return type(n) is int and n%2 == 0
 
    @tc.typecheck
    def foo3(a:int) -> is_even :


### PR DESCRIPTION
Was missing a return statement in is_even example, so is_even would always return None instead of True or False.
