### PR TITLE
Update union predicate to handle 3.6 changes

### DIFF
--- a/typecheck/typing_predicates.py
+++ b/typecheck/typing_predicates.py
@@ -152,12 +152,12 @@ fw.Checker.register(_is_tg_namedtuple, NamedTupleChecker, prepend=True)
 
 
 def _is_tg_union(annotation):
-    return issubclass(annotation, tg.Union)
+    return hasattr(annotation, '__origin__') and annotation.__origin__ is tg.Union
 
 class UnionChecker(fw.Checker):
     def __init__(self, tg_union_class):
         self._cls = tg_union_class
-        self._checks = tuple(fw.Checker.create(p) for p in self._cls.__union_params__)
+        self._checks = tuple(fw.Checker.create(p) for p in self._cls.__args__)
 
     def check(self, value, namespace):
         """


### PR DESCRIPTION
First off, I love this library! Second, it broke when I migrated my code from Python 3.5.2 to 3.6.x.

It seems the internal architecture of the `typing` module changed as of 3.6: https://github.com/agronholm/sphinx-autodoc-typehints/issues/11

Hence why things broke; Unions are now explicitly not allowed to be used with `isinstance` or `issubclass`, and also `__union_params__` is replaced with the generic `__args__` argument. So it goes.

I tested these changes using the following little script:

```
import typing as tg
import typecheck as tc

@tc.typecheck
def foo(x: tg.Union[int, str]):
    print(x)

foo(1)
foo('hello')
foo(1.3)
```

...Which correctly prints for the first two calls, but throws an InputParameterError for the last call.