### PR TITLE
Require “typing” backport module only for Python <3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
 
     # List run-time dependencies here. These will be installed by pip when your
     # project is installed.
-    install_requires = ['typing'],
+    install_requires = ['typing;python_version<"3.5"'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here. If using Python 2.6 or less, then these


### PR DESCRIPTION
From Python 3.5 on, the standard library suffices.