### PR TITLE
Use collections.abc where applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ a predicate on the fly.
 
 The annotation is an expression that evaluates to a tuple or list
 (rather than a type or a predicate);
-more precisely, it can be any ``collections.Sequence`` object.
+more precisely, it can be any ``collections.abc.Sequence`` object.
 This is a very pragmatic extension for programs that do not model
 every little data structure as a class
 but rather make heavy use of the built-in sequence types.
@@ -240,7 +240,7 @@ will be ignored, which is confusing and error-prone.
 
 The annotation is an expression that evaluates to a dictionary
 (rather than a type or a predicate);
-more precisely, it can be any ``collections.Mapping`` object.
+more precisely, it can be any ``collections.abc.Mapping`` object.
 Again, this is a pragmatic extension for programs that do not model
 every little data structure as a class
 but rather make heavy use of the built-in types.
@@ -394,7 +394,7 @@ Also works for bytestrings if you use a bytestring regular expression.
 
 Takes any other annotation ``annot``.
 Allows any argument that is a sequence
-(tuple or list, in fact any ``collections.Sequence``)
+(tuple or list, in fact any ``collections.abc.Sequence``)
 in which each element is allowed by ``annot``.
 Not all violations will be detected because, for efficiency reasons,
 the check will cover only a sample of ``checkonly`` elements of the sequence.
@@ -428,7 +428,7 @@ is ``tg.Sequence[annot]``.
 **tc.list_of(annot, checkonly=4)**:
 
 Just like ``seq_of(annot, checkonly)``, except that it requires the
-sequence to be a ``collections.MutableSequence``.
+sequence to be a ``collections.abc.MutableSequence``.
 
    ```Python
    @tc.typecheck
@@ -443,7 +443,7 @@ is ``tg.MutableSequence[annot]``.
 **tc.map_of(keys_annot, values_annot, checkonly=4)**:
 
 Takes two annotations ``keys_annot`` and ``values_annot``.
-Allows any argument that is a ``collections.Mapping`` (typically a dict)
+Allows any argument that is a ``collections.abc.Mapping`` (typically a dict)
 in which each key is allowed by keys_annot and
 each value is allowed by values_annot.
 Not all violations will be detected because for efficiency reasons,

--- a/typecheck/framework.py
+++ b/typecheck/framework.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import inspect
 import typing as tg
 
@@ -186,7 +186,7 @@ class optional(Checker):
 ################################################################################
 
 def _is_sequence(annotation):
-    return isinstance(annotation, collections.Sequence)
+    return isinstance(annotation, collections.abc.Sequence)
 
 
 class FixedSequenceChecker(Checker):

--- a/typecheck/tc_predicates.py
+++ b/typecheck/tc_predicates.py
@@ -1,5 +1,5 @@
 import builtins
-import collections
+import collections.abc
 import random
 import re as regex_module
 
@@ -7,7 +7,7 @@ import typecheck.framework as fw
 
 
 def ismapping(annotation):
-    return isinstance(annotation, collections.Mapping)
+    return isinstance(annotation, collections.abc.Mapping)
 
 
 class FixedMappingChecker(fw.Checker):
@@ -93,14 +93,14 @@ class sequence_of(fw.Checker):
 
 class seq_of(sequence_of):
     def check(self, value, namespace):
-        return (isinstance(value, collections.Sequence) and
+        return (isinstance(value, collections.abc.Sequence) and
                 not isinstance(value, str) and
                 super().check(value, namespace))
 
 
 class list_of(sequence_of):
     def check(self, value, namespace):
-        return (isinstance(value, collections.MutableSequence) and
+        return (isinstance(value, collections.abc.MutableSequence) and
                 super().check(value, namespace))
 
 
@@ -112,7 +112,7 @@ class map_of(fw.Checker):
         assert self._checkonly >= 1
 
     def check(self, value, namespace):
-        if not isinstance(value, collections.Mapping):
+        if not isinstance(value, collections.abc.Mapping):
             return False
         count = 0
         for mykey, myvalue in value.items():


### PR DESCRIPTION
Beginning with Python 3.3 (the earliest currently-supported version)
Sequence, Mapping, MutableMapping, and the other abstract base classes
for containers appear in in collections.abc. Beginning with Python 3.10,
they are removed from collections.

Using the collections.abc import where applicable provides
forward-compatibility with Python 3.10+ without breaking Python 3.3+.

(Some additional changes are still needed for Python 3.7–3.10 compatibility.)